### PR TITLE
Do not write vacant posts to db

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -37,7 +37,7 @@ def scrape_list(url)
     }
     data[:name] = 'Kamal Abdel Fattah' if data[:id] == 'akamal' # No name in English version
     data[:source] = URI.join(url, URI.escape(data[:source])).to_s unless data[:source].to_s.empty?
-    ScraperWiki.save_sqlite([:id, :term], data)
+    ScraperWiki.save_sqlite([:id, :term], data) unless data[:name] == 'Vaccant Poste'
   end
 
   nexturl = noko.css('li.next a/@href').first.text rescue nil

--- a/scraper.rb
+++ b/scraper.rb
@@ -44,4 +44,4 @@ def scrape_list(url)
   scrape_list URI.join(url, nexturl) if nexturl
 end
 
-scrape_list('http://www.chambredesrepresentants.ma/en/members-house-representatives/all/all/all/all/all/all/all/all')
+scrape_list('http://www.chambredesrepresentants.ma/en/members-house-representatives')


### PR DESCRIPTION
![screen shot 2016-11-28 at 16 50 05](https://cloud.githubusercontent.com/assets/4107953/20677365/c147d364-b58a-11e6-8d54-bb60b1be607d.png)

Some memberships have been vacated but they are still listed on the members pages. However, the URLs within these sections are the URLs of the members that previously held the posts -- though there is no longer biographical data for these members on the pages. Since upstream IDs are formed from the URLs, we end up re-assigning the upstream IDs of the original members to members named 'Vacant Poste'.

This PR does not write member data to the db if the member name is 'Vacant Poste'