### PR TITLE
Tidy gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,11 @@
 # Find out more: https://morph.io/documentation/ruby
 
 source "https://rubygems.org"
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 ruby "2.0.0"
 
-gem "scraperwiki", git: "https://github.com/openaustralia/scraperwiki-ruby.git", branch: "morph_defaults"
+gem "scraperwiki", github: "openaustralia/scraperwiki-ruby", branch: "morph_defaults"
 gem "execjs"
 gem "pry"
 gem "colorize"

--- a/Gemfile
+++ b/Gemfile
@@ -15,3 +15,4 @@ gem "nokogiri"
 gem "open-uri-cached"
 gem "fuzzy_match"
 gem 'wikidata-client', '~> 0.0.7', require: 'wikidata'
+gem 'scraped', github: 'everypolitician/scraped'

--- a/Gemfile
+++ b/Gemfile
@@ -2,17 +2,18 @@
 # specified here will be installed and made available to your morph.io scraper.
 # Find out more: https://morph.io/documentation/ruby
 
-source "https://rubygems.org"
+source 'https://rubygems.org'
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
-ruby "2.0.0"
+ruby '2.0.0'
 
-gem "scraperwiki", github: "openaustralia/scraperwiki-ruby", branch: "morph_defaults"
-gem "execjs"
-gem "pry"
-gem "colorize"
-gem "nokogiri"
-gem "open-uri-cached"
-gem "fuzzy_match"
+gem 'scraperwiki', github: 'openaustralia/scraperwiki-ruby',
+                   branch: 'morph_defaults'
+gem 'execjs'
+gem 'pry'
+gem 'colorize'
+gem 'nokogiri'
+gem 'open-uri-cached'
+gem 'fuzzy_match'
 gem 'wikidata-client', '~> 0.0.7', require: 'wikidata'
 gem 'scraped', github: 'everypolitician/scraped'

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
-ruby '2.0.0'
+ruby '2.3.1'
 
 gem 'scraperwiki', github: 'openaustralia/scraperwiki-ruby',
                    branch: 'morph_defaults'

--- a/Gemfile
+++ b/Gemfile
@@ -7,13 +7,10 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 ruby '2.3.1'
 
-gem 'scraperwiki', github: 'openaustralia/scraperwiki-ruby',
-                   branch: 'morph_defaults'
-gem 'execjs'
-gem 'pry'
 gem 'colorize'
 gem 'nokogiri'
 gem 'open-uri-cached'
-gem 'fuzzy_match'
-gem 'wikidata-client', '~> 0.0.7', require: 'wikidata'
+gem 'pry'
 gem 'scraped', github: 'everypolitician/scraped'
+gem 'scraperwiki', github: 'openaustralia/scraperwiki-ruby',
+                   branch: 'morph_defaults'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,19 +21,10 @@ GEM
   specs:
     coderay (1.1.0)
     colorize (0.7.7)
-    excon (0.45.4)
-    execjs (2.5.2)
-    faraday (0.9.1)
-      multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.10.0)
-      faraday (>= 0.7.4, < 0.10)
     field_serializer (0.2.0)
-    fuzzy_match (2.1.0)
-    hashie (3.4.2)
     httpclient (2.8.2.4)
     method_source (0.8.2)
     mini_portile (0.6.2)
-    multipart-post (2.0.0)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     open-uri-cached (0.0.5)
@@ -46,25 +37,17 @@ GEM
     sqlite3 (1.3.12)
     sqlite_magic (0.0.6)
       sqlite3
-    wikidata-client (0.0.7)
-      excon (~> 0.40)
-      faraday (~> 0.9)
-      faraday_middleware (~> 0.9)
-      hashie (~> 3.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   colorize
-  execjs
-  fuzzy_match
   nokogiri
   open-uri-cached
   pry
   scraped!
   scraperwiki!
-  wikidata-client (~> 0.0.7)
 
 RUBY VERSION
    ruby 2.3.1p112

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,14 @@
 GIT
-  remote: https://github.com/openaustralia/scraperwiki-ruby.git
+  remote: https://github.com/everypolitician/scraped
+  revision: aabdf259f6cc2f746b50352e078a9141450e8d6e
+  specs:
+    scraped (0.1.0)
+      field_serializer
+      nokogiri
+      require_all
+
+GIT
+  remote: https://github.com/openaustralia/scraperwiki-ruby
   revision: fc50176812505e463077d5c673d504a6a234aa78
   branch: morph_defaults
   specs:
@@ -18,9 +27,10 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.10.0)
       faraday (>= 0.7.4, < 0.10)
+    field_serializer (0.2.0)
     fuzzy_match (2.1.0)
     hashie (3.4.2)
-    httpclient (2.6.0.1)
+    httpclient (2.8.2.4)
     method_source (0.8.2)
     mini_portile (0.6.2)
     multipart-post (2.0.0)
@@ -31,9 +41,10 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    require_all (1.3.3)
     slop (3.6.0)
-    sqlite3 (1.3.10)
-    sqlite_magic (0.0.3)
+    sqlite3 (1.3.12)
+    sqlite_magic (0.0.6)
       sqlite3
     wikidata-client (0.0.7)
       excon (~> 0.40)
@@ -51,5 +62,12 @@ DEPENDENCIES
   nokogiri
   open-uri-cached
   pry
+  scraped!
   scraperwiki!
   wikidata-client (~> 0.0.7)
+
+RUBY VERSION
+   ruby 2.3.1p112
+
+BUNDLED WITH
+   1.13.6


### PR DESCRIPTION
Clean up the Gemfile in preparation for the next lot of changes (e.g. https://github.com/everypolitician-scrapers/morocco-house-of-representatives/pull/4)

(NB: Ideally this would have been independent of `95c90bc`, which could be added in #4, but dropping that caused lots of conflicts, so it was easier to just include here even though that goes slightly beyond pure tidying)