### PR TITLE
Remove colorize

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 ruby '2.3.1'
 
-gem 'colorize'
 gem 'nokogiri'
 gem 'open-uri-cached'
 gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,6 @@ GEM
   remote: https://rubygems.org/
   specs:
     coderay (1.1.0)
-    colorize (0.7.7)
     field_serializer (0.2.0)
     httpclient (2.8.2.4)
     method_source (0.8.2)
@@ -42,7 +41,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  colorize
   nokogiri
   open-uri-cached
   pry

--- a/scraper.rb
+++ b/scraper.rb
@@ -4,7 +4,6 @@
 require 'scraperwiki'
 require 'nokogiri'
 require 'open-uri'
-require 'colorize'
 
 require 'pry'
 require 'open-uri/cached'

--- a/scraper.rb
+++ b/scraper.rb
@@ -23,7 +23,6 @@ end
 
 def scrape_list(url)
   noko = noko_for(url)
-  puts url.to_s.yellow
 
   noko.css('ul.lisitng_resultat li').each do |li|
     data = { 


### PR DESCRIPTION
`colorize` doesn’t play nicely with Morph, and isn’t useful enough in local usage, so drop it.