### PR TITLE
Add `next_page` field to MembersPage

### DIFF
--- a/lib/members_page.rb
+++ b/lib/members_page.rb
@@ -6,4 +6,9 @@ class MembersPage < Scraped::HTML
       MemberSection.new(response: response, noko: li)
     end
   end
+
+  field :next_page do
+    nexturl = noko.at_css('li.next a/@href') or return
+    URI.join(url, nexturl.text)
+  end
 end


### PR DESCRIPTION
Each page can tell us the URL of the next one, letting us simplify the scraper considerably.