### PR TITLE
Removing repeat call to #each

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -19,7 +19,7 @@ end
 
 def scrape_list_page(url)
   page = MembersPage.new(response: Scraped::Request.new(url: url).response)
-  page.members.reject { |m| m.name == 'Vaccant Poste' }.each.each do |member|
+  page.members.reject { |m| m.name == 'Vaccant Poste' }.each do |member|
     arabic_member_page = MemberPage.new(
       response: Scraped::Request.new(
         url: member.source.sub('/en/', '/ar/')


### PR DESCRIPTION
On the most recent run, Morph reported that the scraper was scraping 496 pages -- plenty more than expected!

It was discovered that we were making a double call to `#each` in scraper.rb. We don't want to run our block more times than necessary.