### PR TITLE
Strip trailing years from IDs

### DIFF
--- a/lib/member_section.rb
+++ b/lib/member_section.rb
@@ -3,7 +3,7 @@ require 'scraped'
 
 class MemberSection < Scraped::HTML
   field :id do
-    noko.css('h2.name a/@href').text.split('/').last
+    noko.css('h2.name a/@href').text.split('/').last.gsub(/-201(\d+)/, '')
   end
 
   field :name do


### PR DESCRIPTION
IDs have changed from "foo" to "foo-2011-2016". Some double that up
("foo-2011-2016-2011-2016"!), so strip off anything that looks vaguely
similar.