### PR TITLE
Remove hard-coded term from MemberSection

### DIFF
--- a/lib/member_section.rb
+++ b/lib/member_section.rb
@@ -26,8 +26,4 @@ class MemberSection < Scraped::HTML
   field :image do
     noko.css('a.figure img/@src').text
   end
-
-  field :term do
-    9
-  end
 end

--- a/scraper.rb
+++ b/scraper.rb
@@ -27,7 +27,7 @@ def scrape_list_page(url)
       ).response
     )
     data = member.to_h.merge(name__ar: arabic_member_page.name)
-    ScraperWiki.save_sqlite(%i(id term), data)
+    ScraperWiki.save_sqlite(%i(id), data)
   end
 
   scrape_list_page page.next_page if page.next_page


### PR DESCRIPTION
This no longer makes sense as the official site was returning term 10
members but we'd hard-coded term 9.

More generally we're trying to move away from hard-coding
EveryPolitician specific values in the scrapers as we want the scrapers
to be useful in their own right.

Part of https://github.com/everypolitician/everypolitician-data/pull/24613